### PR TITLE
[Do Not Merge] release-1.6

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -421,671 +421,671 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/testing",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/validation",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/validation/path",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery/announced",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery/registered",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/internalversion",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/validation",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/unstructured",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/openapi",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/httpstream",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/rand",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/uuid",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/version",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/netutil",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "c1c4a7fe832857c75cc1d79c8e40d71d5da15fc6"
+			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/admission",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/install",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/apis/apiserver/v1alpha1",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticator",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/authenticatorfactory",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/group",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/anonymous",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/bearertoken",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/headerrequest",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/union",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/request/x509",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/serviceaccount",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/token/tokenfile",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authentication/user",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizer",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/authorizerfactory",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/authorization/union",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/filters",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/negotiation",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/handlers/responsewriters",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/metrics",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/openapi",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/endpoints/request",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/features",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/generic",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/generic/registry",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/registry/rest",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/filters",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/healthz",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/httplog",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/mux",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/openapi",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/options",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/routes",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/routes/data/swagger",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/server/storage",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/errors",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/metrics",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd/util",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/etcd3",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/names",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/storagebackend",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/storage/storagebackend/factory",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/cache",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/feature",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/flag",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/flushwriter",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/logs",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/proxy",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/trace",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/trie",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/webhook",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/pkg/util/wsstream",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/authenticator/token/webhook",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/apiserver/plugin/pkg/authorizer/webhook",
-			"Rev": "87aba34640e70cc17a3e25f2b50a90dfedbd2057"
+			"Rev": "f39838d12c47b401a72e07c08a574abc668829d0"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/scheme",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/api",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/api/v1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/apps",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/apps/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/install",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/v1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/install",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/v1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/v1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/v2alpha1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch/v1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch/v2alpha1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/certificates",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/certificates/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/extensions",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/extensions/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/policy",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/policy/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/v1alpha1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/settings",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/settings/v1alpha1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage/v1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage/v1beta1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/util",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/util/parsers",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/cache",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/latest",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/v1",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/clock",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/homedir",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/integer",
-			"Rev": "5571124637a98cbc6579b0d1cfb78c0fc4b3f035"
+			"Rev": "10cfc597aec7ecaae884b3bfe0853460310ed126"
 		}
 	]
 }

--- a/vendor/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
+++ b/vendor/k8s.io/apiserver/pkg/apis/apiserver/v1alpha1/zz_generated.conversion.go
@@ -70,7 +70,7 @@ func autoConvert_apiserver_AdmissionConfiguration_To_v1alpha1_AdmissionConfigura
 			}
 		}
 	} else {
-		out.Plugins = nil
+		out.Plugins = make([]AdmissionPluginConfiguration, 0)
 	}
 	return nil
 }

--- a/vendor/k8s.io/client-go/pkg/api/helpers.go
+++ b/vendor/k8s.io/client-go/pkg/api/helpers.go
@@ -18,6 +18,7 @@ package api
 
 import (
 	"crypto/md5"
+	"encoding/json"
 	"fmt"
 	"reflect"
 	"strings"
@@ -429,6 +430,14 @@ func NodeSelectorRequirementsAsSelector(nsm []NodeSelectorRequirement) (labels.S
 }
 
 const (
+	// TolerationsAnnotationKey represents the key of tolerations data (json serialized)
+	// in the Annotations of a Pod.
+	TolerationsAnnotationKey string = "scheduler.alpha.kubernetes.io/tolerations"
+
+	// TaintsAnnotationKey represents the key of taints data (json serialized)
+	// in the Annotations of a Node.
+	TaintsAnnotationKey string = "scheduler.alpha.kubernetes.io/taints"
+
 	// SeccompPodAnnotationKey represents the key of a seccomp profile applied
 	// to all containers of a pod.
 	SeccompPodAnnotationKey string = "seccomp.security.alpha.kubernetes.io/pod"
@@ -463,7 +472,25 @@ const (
 	// an object (e.g. secret, config map) before fetching it again from apiserver.
 	// This annotation can be attached to node.
 	ObjectTTLAnnotationKey string = "node.alpha.kubernetes.io/ttl"
+
+	// AffinityAnnotationKey represents the key of affinity data (json serialized)
+	// in the Annotations of a Pod.
+	// TODO: remove when alpha support for affinity is removed
+	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
 )
+
+// GetTolerationsFromPodAnnotations gets the json serialized tolerations data from Pod.Annotations
+// and converts it to the []Toleration type in api.
+func GetTolerationsFromPodAnnotations(annotations map[string]string) ([]Toleration, error) {
+	var tolerations []Toleration
+	if len(annotations) > 0 && annotations[TolerationsAnnotationKey] != "" {
+		err := json.Unmarshal([]byte(annotations[TolerationsAnnotationKey]), &tolerations)
+		if err != nil {
+			return tolerations, err
+		}
+	}
+	return tolerations, nil
+}
 
 // AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
 // Returns true if something was updated, false otherwise.
@@ -548,6 +575,19 @@ func (t *Taint) ToString() string {
 	return fmt.Sprintf("%v=%v:%v", t.Key, t.Value, t.Effect)
 }
 
+// GetTaintsFromNodeAnnotations gets the json serialized taints data from Pod.Annotations
+// and converts it to the []Taint type in api.
+func GetTaintsFromNodeAnnotations(annotations map[string]string) ([]Taint, error) {
+	var taints []Taint
+	if len(annotations) > 0 && annotations[TaintsAnnotationKey] != "" {
+		err := json.Unmarshal([]byte(annotations[TaintsAnnotationKey]), &taints)
+		if err != nil {
+			return []Taint{}, err
+		}
+	}
+	return taints, nil
+}
+
 // SysctlsFromPodAnnotations parses the sysctl annotations into a slice of safe Sysctls
 // and a slice of unsafe Sysctls. This is only a convenience wrapper around
 // SysctlsFromPodAnnotation.
@@ -594,6 +634,21 @@ func PodAnnotationsFromSysctls(sysctls []Sysctl) string {
 		kvs[i] = fmt.Sprintf("%s=%s", sysctls[i].Name, sysctls[i].Value)
 	}
 	return strings.Join(kvs, ",")
+}
+
+// GetAffinityFromPodAnnotations gets the json serialized affinity data from Pod.Annotations
+// and converts it to the Affinity type in api.
+// TODO: remove when alpha support for affinity is removed
+func GetAffinityFromPodAnnotations(annotations map[string]string) (*Affinity, error) {
+	if len(annotations) > 0 && annotations[AffinityAnnotationKey] != "" {
+		var affinity Affinity
+		err := json.Unmarshal([]byte(annotations[AffinityAnnotationKey]), &affinity)
+		if err != nil {
+			return nil, err
+		}
+		return &affinity, nil
+	}
+	return nil, nil
 }
 
 // GetPersistentVolumeClass returns StorageClassName.

--- a/vendor/k8s.io/client-go/pkg/api/v1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/api/v1/zz_generated.conversion.go
@@ -565,7 +565,11 @@ func Convert_v1_CephFSVolumeSource_To_api_CephFSVolumeSource(in *CephFSVolumeSou
 }
 
 func autoConvert_api_CephFSVolumeSource_To_v1_CephFSVolumeSource(in *api.CephFSVolumeSource, out *CephFSVolumeSource, s conversion.Scope) error {
-	out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
+	if in.Monitors == nil {
+		out.Monitors = make([]string, 0)
+	} else {
+		out.Monitors = *(*[]string)(unsafe.Pointer(&in.Monitors))
+	}
 	out.Path = in.Path
 	out.User = in.User
 	out.SecretFile = in.SecretFile
@@ -656,7 +660,11 @@ func Convert_v1_ComponentStatusList_To_api_ComponentStatusList(in *ComponentStat
 
 func autoConvert_api_ComponentStatusList_To_v1_ComponentStatusList(in *api.ComponentStatusList, out *ComponentStatusList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ComponentStatus)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ComponentStatus, 0)
+	} else {
+		out.Items = *(*[]ComponentStatus)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -746,7 +754,11 @@ func Convert_v1_ConfigMapList_To_api_ConfigMapList(in *ConfigMapList, out *api.C
 
 func autoConvert_api_ConfigMapList_To_v1_ConfigMapList(in *api.ConfigMapList, out *ConfigMapList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ConfigMap)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ConfigMap, 0)
+	} else {
+		out.Items = *(*[]ConfigMap)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -879,7 +891,11 @@ func Convert_v1_ContainerImage_To_api_ContainerImage(in *ContainerImage, out *ap
 }
 
 func autoConvert_api_ContainerImage_To_v1_ContainerImage(in *api.ContainerImage, out *ContainerImage, s conversion.Scope) error {
-	out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
+	if in.Names == nil {
+		out.Names = make([]string, 0)
+	} else {
+		out.Names = *(*[]string)(unsafe.Pointer(&in.Names))
+	}
 	out.SizeBytes = in.SizeBytes
 	return nil
 }
@@ -1246,7 +1262,11 @@ func Convert_v1_Endpoints_To_api_Endpoints(in *Endpoints, out *api.Endpoints, s 
 
 func autoConvert_api_Endpoints_To_v1_Endpoints(in *api.Endpoints, out *Endpoints, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subsets = *(*[]EndpointSubset)(unsafe.Pointer(&in.Subsets))
+	if in.Subsets == nil {
+		out.Subsets = make([]EndpointSubset, 0)
+	} else {
+		out.Subsets = *(*[]EndpointSubset)(unsafe.Pointer(&in.Subsets))
+	}
 	return nil
 }
 
@@ -1266,7 +1286,11 @@ func Convert_v1_EndpointsList_To_api_EndpointsList(in *EndpointsList, out *api.E
 
 func autoConvert_api_EndpointsList_To_v1_EndpointsList(in *api.EndpointsList, out *EndpointsList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Endpoints)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Endpoints, 0)
+	} else {
+		out.Items = *(*[]Endpoints)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1396,7 +1420,11 @@ func Convert_v1_EventList_To_api_EventList(in *EventList, out *api.EventList, s 
 
 func autoConvert_api_EventList_To_v1_EventList(in *api.EventList, out *EventList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Event, 0)
+	} else {
+		out.Items = *(*[]Event)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1455,7 +1483,11 @@ func Convert_v1_FCVolumeSource_To_api_FCVolumeSource(in *FCVolumeSource, out *ap
 }
 
 func autoConvert_api_FCVolumeSource_To_v1_FCVolumeSource(in *api.FCVolumeSource, out *FCVolumeSource, s conversion.Scope) error {
-	out.TargetWWNs = *(*[]string)(unsafe.Pointer(&in.TargetWWNs))
+	if in.TargetWWNs == nil {
+		out.TargetWWNs = make([]string, 0)
+	} else {
+		out.TargetWWNs = *(*[]string)(unsafe.Pointer(&in.TargetWWNs))
+	}
 	out.Lun = (*int32)(unsafe.Pointer(in.Lun))
 	out.FSType = in.FSType
 	out.ReadOnly = in.ReadOnly
@@ -1802,7 +1834,11 @@ func Convert_v1_LimitRangeList_To_api_LimitRangeList(in *LimitRangeList, out *ap
 
 func autoConvert_api_LimitRangeList_To_v1_LimitRangeList(in *api.LimitRangeList, out *LimitRangeList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]LimitRange)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]LimitRange, 0)
+	} else {
+		out.Items = *(*[]LimitRange)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1820,7 +1856,11 @@ func Convert_v1_LimitRangeSpec_To_api_LimitRangeSpec(in *LimitRangeSpec, out *ap
 }
 
 func autoConvert_api_LimitRangeSpec_To_v1_LimitRangeSpec(in *api.LimitRangeSpec, out *LimitRangeSpec, s conversion.Scope) error {
-	out.Limits = *(*[]LimitRangeItem)(unsafe.Pointer(&in.Limits))
+	if in.Limits == nil {
+		out.Limits = make([]LimitRangeItem, 0)
+	} else {
+		out.Limits = *(*[]LimitRangeItem)(unsafe.Pointer(&in.Limits))
+	}
 	return nil
 }
 
@@ -1859,7 +1899,7 @@ func autoConvert_api_List_To_v1_List(in *api.List, out *List, s conversion.Scope
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]runtime.RawExtension, 0)
 	}
 	return nil
 }
@@ -2022,7 +2062,11 @@ func Convert_v1_NamespaceList_To_api_NamespaceList(in *NamespaceList, out *api.N
 
 func autoConvert_api_NamespaceList_To_v1_NamespaceList(in *api.NamespaceList, out *NamespaceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Namespace)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Namespace, 0)
+	} else {
+		out.Items = *(*[]Namespace)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2198,7 +2242,11 @@ func Convert_v1_NodeList_To_api_NodeList(in *NodeList, out *api.NodeList, s conv
 
 func autoConvert_api_NodeList_To_v1_NodeList(in *api.NodeList, out *NodeList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Node)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Node, 0)
+	} else {
+		out.Items = *(*[]Node)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2252,7 +2300,11 @@ func Convert_v1_NodeSelector_To_api_NodeSelector(in *NodeSelector, out *api.Node
 }
 
 func autoConvert_api_NodeSelector_To_v1_NodeSelector(in *api.NodeSelector, out *NodeSelector, s conversion.Scope) error {
-	out.NodeSelectorTerms = *(*[]NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
+	if in.NodeSelectorTerms == nil {
+		out.NodeSelectorTerms = make([]NodeSelectorTerm, 0)
+	} else {
+		out.NodeSelectorTerms = *(*[]NodeSelectorTerm)(unsafe.Pointer(&in.NodeSelectorTerms))
+	}
 	return nil
 }
 
@@ -2292,7 +2344,11 @@ func Convert_v1_NodeSelectorTerm_To_api_NodeSelectorTerm(in *NodeSelectorTerm, o
 }
 
 func autoConvert_api_NodeSelectorTerm_To_v1_NodeSelectorTerm(in *api.NodeSelectorTerm, out *NodeSelectorTerm, s conversion.Scope) error {
-	out.MatchExpressions = *(*[]NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	if in.MatchExpressions == nil {
+		out.MatchExpressions = make([]NodeSelectorRequirement, 0)
+	} else {
+		out.MatchExpressions = *(*[]NodeSelectorRequirement)(unsafe.Pointer(&in.MatchExpressions))
+	}
 	return nil
 }
 
@@ -2574,7 +2630,11 @@ func Convert_v1_PersistentVolumeClaimList_To_api_PersistentVolumeClaimList(in *P
 
 func autoConvert_api_PersistentVolumeClaimList_To_v1_PersistentVolumeClaimList(in *api.PersistentVolumeClaimList, out *PersistentVolumeClaimList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]PersistentVolumeClaim)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]PersistentVolumeClaim, 0)
+	} else {
+		out.Items = *(*[]PersistentVolumeClaim)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -2685,7 +2745,7 @@ func autoConvert_api_PersistentVolumeList_To_v1_PersistentVolumeList(in *api.Per
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PersistentVolume, 0)
 	}
 	return nil
 }
@@ -2980,7 +3040,11 @@ func autoConvert_api_PodExecOptions_To_v1_PodExecOptions(in *api.PodExecOptions,
 	out.Stderr = in.Stderr
 	out.TTY = in.TTY
 	out.Container = in.Container
-	out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
+	if in.Command == nil {
+		out.Command = make([]string, 0)
+	} else {
+		out.Command = *(*[]string)(unsafe.Pointer(&in.Command))
+	}
 	return nil
 }
 
@@ -3019,7 +3083,7 @@ func autoConvert_api_PodList_To_v1_PodList(in *api.PodList, out *PodList, s conv
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Pod, 0)
 	}
 	return nil
 }
@@ -3192,7 +3256,11 @@ func autoConvert_api_PodSpec_To_v1_PodSpec(in *api.PodSpec, out *PodSpec, s conv
 		out.Volumes = nil
 	}
 	out.InitContainers = *(*[]Container)(unsafe.Pointer(&in.InitContainers))
-	out.Containers = *(*[]Container)(unsafe.Pointer(&in.Containers))
+	if in.Containers == nil {
+		out.Containers = make([]Container, 0)
+	} else {
+		out.Containers = *(*[]Container)(unsafe.Pointer(&in.Containers))
+	}
 	out.RestartPolicy = RestartPolicy(in.RestartPolicy)
 	out.TerminationGracePeriodSeconds = (*int64)(unsafe.Pointer(in.TerminationGracePeriodSeconds))
 	out.ActiveDeadlineSeconds = (*int64)(unsafe.Pointer(in.ActiveDeadlineSeconds))
@@ -3326,7 +3394,7 @@ func autoConvert_api_PodTemplateList_To_v1_PodTemplateList(in *api.PodTemplateLi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodTemplate, 0)
 	}
 	return nil
 }
@@ -3486,7 +3554,11 @@ func Convert_v1_ProjectedVolumeSource_To_api_ProjectedVolumeSource(in *Projected
 }
 
 func autoConvert_api_ProjectedVolumeSource_To_v1_ProjectedVolumeSource(in *api.ProjectedVolumeSource, out *ProjectedVolumeSource, s conversion.Scope) error {
-	out.Sources = *(*[]VolumeProjection)(unsafe.Pointer(&in.Sources))
+	if in.Sources == nil {
+		out.Sources = make([]VolumeProjection, 0)
+	} else {
+		out.Sources = *(*[]VolumeProjection)(unsafe.Pointer(&in.Sources))
+	}
 	out.DefaultMode = (*int32)(unsafe.Pointer(in.DefaultMode))
 	return nil
 }
@@ -3538,7 +3610,11 @@ func Convert_v1_RBDVolumeSource_To_api_RBDVolumeSource(in *RBDVolumeSource, out 
 }
 
 func autoConvert_api_RBDVolumeSource_To_v1_RBDVolumeSource(in *api.RBDVolumeSource, out *RBDVolumeSource, s conversion.Scope) error {
-	out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
+	if in.CephMonitors == nil {
+		out.CephMonitors = make([]string, 0)
+	} else {
+		out.CephMonitors = *(*[]string)(unsafe.Pointer(&in.CephMonitors))
+	}
 	out.RBDImage = in.RBDImage
 	out.FSType = in.FSType
 	out.RBDPool = in.RBDPool
@@ -3567,7 +3643,11 @@ func Convert_v1_RangeAllocation_To_api_RangeAllocation(in *RangeAllocation, out 
 func autoConvert_api_RangeAllocation_To_v1_RangeAllocation(in *api.RangeAllocation, out *RangeAllocation, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
 	out.Range = in.Range
-	out.Data = *(*[]byte)(unsafe.Pointer(&in.Data))
+	if in.Data == nil {
+		out.Data = make([]byte, 0)
+	} else {
+		out.Data = *(*[]byte)(unsafe.Pointer(&in.Data))
+	}
 	return nil
 }
 
@@ -3662,7 +3742,7 @@ func autoConvert_api_ReplicationControllerList_To_v1_ReplicationControllerList(i
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ReplicationController, 0)
 	}
 	return nil
 }
@@ -3799,7 +3879,11 @@ func Convert_v1_ResourceQuotaList_To_api_ResourceQuotaList(in *ResourceQuotaList
 
 func autoConvert_api_ResourceQuotaList_To_v1_ResourceQuotaList(in *api.ResourceQuotaList, out *ResourceQuotaList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ResourceQuota)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ResourceQuota, 0)
+	} else {
+		out.Items = *(*[]ResourceQuota)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -4027,7 +4111,7 @@ func autoConvert_api_SecretList_To_v1_SecretList(in *api.SecretList, out *Secret
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Secret, 0)
 	}
 	return nil
 }
@@ -4202,7 +4286,11 @@ func Convert_v1_ServiceAccountList_To_api_ServiceAccountList(in *ServiceAccountL
 
 func autoConvert_api_ServiceAccountList_To_v1_ServiceAccountList(in *api.ServiceAccountList, out *ServiceAccountList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ServiceAccount)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ServiceAccount, 0)
+	} else {
+		out.Items = *(*[]ServiceAccount)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -4241,7 +4329,7 @@ func autoConvert_api_ServiceList_To_v1_ServiceList(in *api.ServiceList, out *Ser
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Service, 0)
 	}
 	return nil
 }

--- a/vendor/k8s.io/client-go/pkg/apis/apps/v1beta1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/apps/v1beta1/zz_generated.conversion.go
@@ -110,7 +110,7 @@ func autoConvert_apps_StatefulSetList_To_v1beta1_StatefulSetList(in *apps.Statef
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]StatefulSet, 0)
 	}
 	return nil
 }

--- a/vendor/k8s.io/client-go/pkg/apis/autoscaling/v1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/autoscaling/v1/zz_generated.conversion.go
@@ -149,7 +149,7 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v1_HorizontalPodAuto
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]HorizontalPodAutoscaler, 0)
 	}
 	return nil
 }

--- a/vendor/k8s.io/client-go/pkg/apis/autoscaling/v2alpha1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/autoscaling/v2alpha1/zz_generated.conversion.go
@@ -132,7 +132,11 @@ func Convert_v2alpha1_HorizontalPodAutoscalerList_To_autoscaling_HorizontalPodAu
 
 func autoConvert_autoscaling_HorizontalPodAutoscalerList_To_v2alpha1_HorizontalPodAutoscalerList(in *autoscaling.HorizontalPodAutoscalerList, out *HorizontalPodAutoscalerList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]HorizontalPodAutoscaler)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]HorizontalPodAutoscaler, 0)
+	} else {
+		out.Items = *(*[]HorizontalPodAutoscaler)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -186,7 +190,11 @@ func autoConvert_autoscaling_HorizontalPodAutoscalerStatus_To_v2alpha1_Horizonta
 	out.LastScaleTime = (*v1.Time)(unsafe.Pointer(in.LastScaleTime))
 	out.CurrentReplicas = in.CurrentReplicas
 	out.DesiredReplicas = in.DesiredReplicas
-	out.CurrentMetrics = *(*[]MetricStatus)(unsafe.Pointer(&in.CurrentMetrics))
+	if in.CurrentMetrics == nil {
+		out.CurrentMetrics = make([]MetricStatus, 0)
+	} else {
+		out.CurrentMetrics = *(*[]MetricStatus)(unsafe.Pointer(&in.CurrentMetrics))
+	}
 	return nil
 }
 

--- a/vendor/k8s.io/client-go/pkg/apis/batch/v1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/batch/v1/zz_generated.conversion.go
@@ -140,7 +140,7 @@ func autoConvert_batch_JobList_To_v1_JobList(in *batch.JobList, out *JobList, s 
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Job, 0)
 	}
 	return nil
 }

--- a/vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1/zz_generated.conversion.go
@@ -115,7 +115,7 @@ func autoConvert_batch_CronJobList_To_v2alpha1_CronJobList(in *batch.CronJobList
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]CronJob, 0)
 	}
 	return nil
 }

--- a/vendor/k8s.io/client-go/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/certificates/v1beta1/zz_generated.conversion.go
@@ -114,7 +114,11 @@ func Convert_v1beta1_CertificateSigningRequestList_To_certificates_CertificateSi
 
 func autoConvert_certificates_CertificateSigningRequestList_To_v1beta1_CertificateSigningRequestList(in *certificates.CertificateSigningRequestList, out *CertificateSigningRequestList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]CertificateSigningRequest)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CertificateSigningRequest, 0)
+	} else {
+		out.Items = *(*[]CertificateSigningRequest)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -137,7 +141,11 @@ func Convert_v1beta1_CertificateSigningRequestSpec_To_certificates_CertificateSi
 }
 
 func autoConvert_certificates_CertificateSigningRequestSpec_To_v1beta1_CertificateSigningRequestSpec(in *certificates.CertificateSigningRequestSpec, out *CertificateSigningRequestSpec, s conversion.Scope) error {
-	out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
+	if in.Request == nil {
+		out.Request = make([]byte, 0)
+	} else {
+		out.Request = *(*[]byte)(unsafe.Pointer(&in.Request))
+	}
 	out.Usages = *(*[]KeyUsage)(unsafe.Pointer(&in.Usages))
 	out.Username = in.Username
 	out.UID = in.UID

--- a/vendor/k8s.io/client-go/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/extensions/v1beta1/zz_generated.conversion.go
@@ -206,7 +206,11 @@ func Convert_v1beta1_CustomMetricCurrentStatusList_To_extensions_CustomMetricCur
 }
 
 func autoConvert_extensions_CustomMetricCurrentStatusList_To_v1beta1_CustomMetricCurrentStatusList(in *extensions.CustomMetricCurrentStatusList, out *CustomMetricCurrentStatusList, s conversion.Scope) error {
-	out.Items = *(*[]CustomMetricCurrentStatus)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CustomMetricCurrentStatus, 0)
+	} else {
+		out.Items = *(*[]CustomMetricCurrentStatus)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -244,7 +248,11 @@ func Convert_v1beta1_CustomMetricTargetList_To_extensions_CustomMetricTargetList
 }
 
 func autoConvert_extensions_CustomMetricTargetList_To_v1beta1_CustomMetricTargetList(in *extensions.CustomMetricTargetList, out *CustomMetricTargetList, s conversion.Scope) error {
-	out.Items = *(*[]CustomMetricTarget)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]CustomMetricTarget, 0)
+	} else {
+		out.Items = *(*[]CustomMetricTarget)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -313,7 +321,7 @@ func autoConvert_extensions_DaemonSetList_To_v1beta1_DaemonSetList(in *extension
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]DaemonSet, 0)
 	}
 	return nil
 }
@@ -513,7 +521,7 @@ func autoConvert_extensions_DeploymentList_To_v1beta1_DeploymentList(in *extensi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]Deployment, 0)
 	}
 	return nil
 }
@@ -698,7 +706,11 @@ func Convert_v1beta1_HTTPIngressRuleValue_To_extensions_HTTPIngressRuleValue(in 
 }
 
 func autoConvert_extensions_HTTPIngressRuleValue_To_v1beta1_HTTPIngressRuleValue(in *extensions.HTTPIngressRuleValue, out *HTTPIngressRuleValue, s conversion.Scope) error {
-	out.Paths = *(*[]HTTPIngressPath)(unsafe.Pointer(&in.Paths))
+	if in.Paths == nil {
+		out.Paths = make([]HTTPIngressPath, 0)
+	} else {
+		out.Paths = *(*[]HTTPIngressPath)(unsafe.Pointer(&in.Paths))
+	}
 	return nil
 }
 
@@ -808,7 +820,11 @@ func Convert_v1beta1_IngressList_To_extensions_IngressList(in *IngressList, out 
 
 func autoConvert_extensions_IngressList_To_v1beta1_IngressList(in *extensions.IngressList, out *IngressList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Ingress)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Ingress, 0)
+	} else {
+		out.Items = *(*[]Ingress)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -980,7 +996,11 @@ func Convert_v1beta1_NetworkPolicyList_To_extensions_NetworkPolicyList(in *Netwo
 
 func autoConvert_extensions_NetworkPolicyList_To_v1beta1_NetworkPolicyList(in *extensions.NetworkPolicyList, out *NetworkPolicyList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]NetworkPolicy)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]NetworkPolicy, 0)
+	} else {
+		out.Items = *(*[]NetworkPolicy)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1103,7 +1123,7 @@ func autoConvert_extensions_PodSecurityPolicyList_To_v1beta1_PodSecurityPolicyLi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodSecurityPolicy, 0)
 	}
 	return nil
 }
@@ -1279,7 +1299,7 @@ func autoConvert_extensions_ReplicaSetList_To_v1beta1_ReplicaSetList(in *extensi
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ReplicaSet, 0)
 	}
 	return nil
 }
@@ -1571,7 +1591,11 @@ func Convert_v1beta1_ThirdPartyResourceDataList_To_extensions_ThirdPartyResource
 
 func autoConvert_extensions_ThirdPartyResourceDataList_To_v1beta1_ThirdPartyResourceDataList(in *extensions.ThirdPartyResourceDataList, out *ThirdPartyResourceDataList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ThirdPartyResourceData)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ThirdPartyResourceData, 0)
+	} else {
+		out.Items = *(*[]ThirdPartyResourceData)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -1591,7 +1615,11 @@ func Convert_v1beta1_ThirdPartyResourceList_To_extensions_ThirdPartyResourceList
 
 func autoConvert_extensions_ThirdPartyResourceList_To_v1beta1_ThirdPartyResourceList(in *extensions.ThirdPartyResourceList, out *ThirdPartyResourceList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ThirdPartyResource)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ThirdPartyResource, 0)
+	} else {
+		out.Items = *(*[]ThirdPartyResource)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/vendor/k8s.io/client-go/pkg/apis/policy/v1beta1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/policy/v1beta1/zz_generated.conversion.go
@@ -111,7 +111,11 @@ func Convert_v1beta1_PodDisruptionBudgetList_To_policy_PodDisruptionBudgetList(i
 
 func autoConvert_policy_PodDisruptionBudgetList_To_v1beta1_PodDisruptionBudgetList(in *policy.PodDisruptionBudgetList, out *PodDisruptionBudgetList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]PodDisruptionBudget)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]PodDisruptionBudget, 0)
+	} else {
+		out.Items = *(*[]PodDisruptionBudget)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/vendor/k8s.io/client-go/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/rbac/v1alpha1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1alpha1_ClusterRole_To_rbac_ClusterRole(in *ClusterRole, out *rbac
 
 func autoConvert_rbac_ClusterRole_To_v1alpha1_ClusterRole(in *rbac.ClusterRole, out *ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -118,7 +122,7 @@ func autoConvert_rbac_ClusterRoleBinding_To_v1alpha1_ClusterRoleBinding(in *rbac
 			}
 		}
 	} else {
-		out.Subjects = nil
+		out.Subjects = make([]Subject, 0)
 	}
 	if err := Convert_rbac_RoleRef_To_v1alpha1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
@@ -183,7 +187,7 @@ func autoConvert_rbac_ClusterRoleBindingList_To_v1alpha1_ClusterRoleBindingList(
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]ClusterRoleBinding, 0)
 	}
 	return nil
 }
@@ -204,7 +208,11 @@ func Convert_v1alpha1_ClusterRoleList_To_rbac_ClusterRoleList(in *ClusterRoleLis
 
 func autoConvert_rbac_ClusterRoleList_To_v1alpha1_ClusterRoleList(in *rbac.ClusterRoleList, out *ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRole, 0)
+	} else {
+		out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -226,7 +234,11 @@ func Convert_v1alpha1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.Po
 }
 
 func autoConvert_rbac_PolicyRule_To_v1alpha1_PolicyRule(in *rbac.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	if in.Verbs == nil {
+		out.Verbs = make([]string, 0)
+	} else {
+		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	}
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -272,7 +284,11 @@ func Convert_v1alpha1_Role_To_rbac_Role(in *Role, out *rbac.Role, s conversion.S
 
 func autoConvert_rbac_Role_To_v1alpha1_Role(in *rbac.Role, out *Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -314,7 +330,7 @@ func autoConvert_rbac_RoleBinding_To_v1alpha1_RoleBinding(in *rbac.RoleBinding, 
 			}
 		}
 	} else {
-		out.Subjects = nil
+		out.Subjects = make([]Subject, 0)
 	}
 	if err := Convert_rbac_RoleRef_To_v1alpha1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
@@ -357,7 +373,7 @@ func autoConvert_rbac_RoleBindingList_To_v1alpha1_RoleBindingList(in *rbac.RoleB
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]RoleBinding, 0)
 	}
 	return nil
 }
@@ -378,7 +394,11 @@ func Convert_v1alpha1_RoleList_To_rbac_RoleList(in *RoleList, out *rbac.RoleList
 
 func autoConvert_rbac_RoleList_To_v1alpha1_RoleList(in *rbac.RoleList, out *RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Role, 0)
+	} else {
+		out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/vendor/k8s.io/client-go/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/rbac/v1beta1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1beta1_ClusterRole_To_rbac_ClusterRole(in *ClusterRole, out *rbac.
 
 func autoConvert_rbac_ClusterRole_To_v1beta1_ClusterRole(in *rbac.ClusterRole, out *ClusterRole, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -99,7 +103,11 @@ func Convert_v1beta1_ClusterRoleBinding_To_rbac_ClusterRoleBinding(in *ClusterRo
 
 func autoConvert_rbac_ClusterRoleBinding_To_v1beta1_ClusterRoleBinding(in *rbac.ClusterRoleBinding, out *ClusterRoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	if in.Subjects == nil {
+		out.Subjects = make([]Subject, 0)
+	} else {
+		out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	}
 	if err := Convert_rbac_RoleRef_To_v1beta1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -144,7 +152,11 @@ func Convert_v1beta1_ClusterRoleBindingList_To_rbac_ClusterRoleBindingList(in *C
 
 func autoConvert_rbac_ClusterRoleBindingList_To_v1beta1_ClusterRoleBindingList(in *rbac.ClusterRoleBindingList, out *ClusterRoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRoleBinding)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRoleBinding, 0)
+	} else {
+		out.Items = *(*[]ClusterRoleBinding)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -164,7 +176,11 @@ func Convert_v1beta1_ClusterRoleList_To_rbac_ClusterRoleList(in *ClusterRoleList
 
 func autoConvert_rbac_ClusterRoleList_To_v1beta1_ClusterRoleList(in *rbac.ClusterRoleList, out *ClusterRoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]ClusterRole, 0)
+	} else {
+		out.Items = *(*[]ClusterRole)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -186,7 +202,11 @@ func Convert_v1beta1_PolicyRule_To_rbac_PolicyRule(in *PolicyRule, out *rbac.Pol
 }
 
 func autoConvert_rbac_PolicyRule_To_v1beta1_PolicyRule(in *rbac.PolicyRule, out *PolicyRule, s conversion.Scope) error {
-	out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	if in.Verbs == nil {
+		out.Verbs = make([]string, 0)
+	} else {
+		out.Verbs = *(*[]string)(unsafe.Pointer(&in.Verbs))
+	}
 	out.APIGroups = *(*[]string)(unsafe.Pointer(&in.APIGroups))
 	out.Resources = *(*[]string)(unsafe.Pointer(&in.Resources))
 	out.ResourceNames = *(*[]string)(unsafe.Pointer(&in.ResourceNames))
@@ -232,7 +252,11 @@ func Convert_v1beta1_Role_To_rbac_Role(in *Role, out *rbac.Role, s conversion.Sc
 
 func autoConvert_rbac_Role_To_v1beta1_Role(in *rbac.Role, out *Role, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	if in.Rules == nil {
+		out.Rules = make([]PolicyRule, 0)
+	} else {
+		out.Rules = *(*[]PolicyRule)(unsafe.Pointer(&in.Rules))
+	}
 	return nil
 }
 
@@ -255,7 +279,11 @@ func Convert_v1beta1_RoleBinding_To_rbac_RoleBinding(in *RoleBinding, out *rbac.
 
 func autoConvert_rbac_RoleBinding_To_v1beta1_RoleBinding(in *rbac.RoleBinding, out *RoleBinding, s conversion.Scope) error {
 	out.ObjectMeta = in.ObjectMeta
-	out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	if in.Subjects == nil {
+		out.Subjects = make([]Subject, 0)
+	} else {
+		out.Subjects = *(*[]Subject)(unsafe.Pointer(&in.Subjects))
+	}
 	if err := Convert_rbac_RoleRef_To_v1beta1_RoleRef(&in.RoleRef, &out.RoleRef, s); err != nil {
 		return err
 	}
@@ -278,7 +306,11 @@ func Convert_v1beta1_RoleBindingList_To_rbac_RoleBindingList(in *RoleBindingList
 
 func autoConvert_rbac_RoleBindingList_To_v1beta1_RoleBindingList(in *rbac.RoleBindingList, out *RoleBindingList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]RoleBinding)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]RoleBinding, 0)
+	} else {
+		out.Items = *(*[]RoleBinding)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 
@@ -298,7 +330,11 @@ func Convert_v1beta1_RoleList_To_rbac_RoleList(in *RoleList, out *rbac.RoleList,
 
 func autoConvert_rbac_RoleList_To_v1beta1_RoleList(in *rbac.RoleList, out *RoleList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]Role, 0)
+	} else {
+		out.Items = *(*[]Role)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/vendor/k8s.io/client-go/pkg/apis/settings/v1alpha1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/settings/v1alpha1/zz_generated.conversion.go
@@ -101,7 +101,7 @@ func autoConvert_settings_PodPresetList_To_v1alpha1_PodPresetList(in *settings.P
 			}
 		}
 	} else {
-		out.Items = nil
+		out.Items = make([]PodPreset, 0)
 	}
 	return nil
 }

--- a/vendor/k8s.io/client-go/pkg/apis/storage/v1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/storage/v1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1_StorageClassList_To_storage_StorageClassList(in *StorageClassLis
 
 func autoConvert_storage_StorageClassList_To_v1_StorageClassList(in *storage.StorageClassList, out *StorageClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]StorageClass, 0)
+	} else {
+		out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/vendor/k8s.io/client-go/pkg/apis/storage/v1beta1/zz_generated.conversion.go
+++ b/vendor/k8s.io/client-go/pkg/apis/storage/v1beta1/zz_generated.conversion.go
@@ -76,7 +76,11 @@ func Convert_v1beta1_StorageClassList_To_storage_StorageClassList(in *StorageCla
 
 func autoConvert_storage_StorageClassList_To_v1beta1_StorageClassList(in *storage.StorageClassList, out *StorageClassList, s conversion.Scope) error {
 	out.ListMeta = in.ListMeta
-	out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	if in.Items == nil {
+		out.Items = make([]StorageClass, 0)
+	} else {
+		out.Items = *(*[]StorageClass)(unsafe.Pointer(&in.Items))
+	}
 	return nil
 }
 

--- a/vendor/k8s.io/client-go/pkg/version/base.go
+++ b/vendor/k8s.io/client-go/pkg/version/base.go
@@ -39,8 +39,8 @@ var (
 	// them irrelevant. (Next we'll take it out, which may muck with
 	// scripts consuming the kubectl version output - but most of
 	// these should be looking at gitVersion already anyways.)
-	gitMajor string = "" // major version, always numeric
-	gitMinor string = "" // minor version, numeric possibly followed by "+"
+	gitMajor string = "1"  // major version, always numeric
+	gitMinor string = "6+" // minor version, numeric possibly followed by "+"
 
 	// semantic version, derived by build scripts (see
 	// https://github.com/kubernetes/kubernetes/blob/master/docs/design/versioning.md
@@ -51,7 +51,7 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v0.0.0-master+$Format:%h$"
+	gitVersion   string = "v1.6.1-beta.0+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 


### PR DESCRIPTION
Generated by bot.

The release-3.0 of client-go, and release-1.6 branches of apimachinery, apiserver, kube-aggregator, and sample-apiserver are tracking relesae-1.6 of kubernetes. These branches might depend on each other, but not on commit in the master branch.

The PR batch:
https://github.com/kubernetes/sample-apiserver/pull/4
https://github.com/kubernetes/kube-aggregator/pull/6
https://github.com/kubernetes/apiserver/pull/6
https://github.com/kubernetes/client-go/pull/160
no change to the release 1.6 branch of apimachinery

cc @deads2k @sttts 