### PR TITLE
Add namespace manifest

### DIFF
--- a/artifacts/example/ns.yaml
+++ b/artifacts/example/ns.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: wardle
+spec:
+  finalizers:
+  - kubernetes


### PR DESCRIPTION
By default the wardle namespace does not exist. This patch adds a wardle namespace manifest.